### PR TITLE
[9.x] Attributes support on default component slot

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -5,7 +5,6 @@ namespace Illuminate\View\Concerns;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
-use Illuminate\Support\HtmlString;
 use Illuminate\View\ComponentSlot;
 
 trait ManagesComponents
@@ -115,7 +114,7 @@ trait ManagesComponents
      */
     protected function componentData()
     {
-        $defaultSlot = new HtmlString(trim(ob_get_clean()));
+        $defaultSlot = new ComponentSlot(trim(ob_get_clean()));
 
         $slots = array_merge([
             '__default' => $defaultSlot,


### PR DESCRIPTION
Same as: https://github.com/laravel/framework/pull/48039 but for Laravel 9